### PR TITLE
🧹 Janitor: fix lints and formatting

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2026-03-16: Replaced let with const for variables assigned only once, removed unnecessary continues and unused variables, and enforced strict equality.

--- a/lib/extractor/common/urlsFromString/index.js
+++ b/lib/extractor/common/urlsFromString/index.js
@@ -1,21 +1,21 @@
-const mustString = require('../../../type/mustString')
-const urlRegexSafe = require('url-regex-safe')
+const mustString = require("../../../type/mustString");
+const urlRegexSafe = require("url-regex-safe");
 
 /**
  * Extract all urls from a string
- * @param {string} text Text to have urls being extracted 
+ * @param {string} text Text to have urls being extracted
  * @returns {Array<string>} Links extracted
  */
 function extractURLsFromString(text) {
-    const matches = mustString(text).match(urlRegexSafe())
-    if (!matches) {
-        return []
-    }
-    let ret = []
-    for (const match of matches) {
-        ret.push(match)
-    }
-    return ret
+	const matches = mustString(text).match(urlRegexSafe());
+	if (!matches) {
+		return [];
+	}
+	const ret = [];
+	for (const match of matches) {
+		ret.push(match);
+	}
+	return ret;
 }
 
-module.exports = extractURLsFromString
+module.exports = extractURLsFromString;

--- a/lib/list/segment/index.js
+++ b/lib/list/segment/index.js
@@ -6,13 +6,13 @@
  */
 
 function segment(list, blockSize) {
-    let ret = []
-    while (list.length !== 0) {
-        const cur = list.slice(0, blockSize)
-        ret.push(cur)
-        list = list.slice(blockSize)
-    }
-    return ret
+	const ret = [];
+	while (list.length !== 0) {
+		const cur = list.slice(0, blockSize);
+		ret.push(cur);
+		list = list.slice(blockSize);
+	}
+	return ret;
 }
 
-module.exports = segment
+module.exports = segment;

--- a/lib/list/segment/index.test.js
+++ b/lib/list/segment/index.test.js
@@ -1,25 +1,15 @@
-const { TestScheduler } = require('jest')
-const segment = require('.')
+const segment = require(".");
 
 test("segment with blockSize = 1", () => {
-    const input = [1, 2, 3, 4]
-    const blockSize = 1
-    const output = [
-        [1],
-        [2],
-        [3],
-        [4]
-    ]
-    expect(segment(input, blockSize)).toStrictEqual(output)
-})
+	const input = [1, 2, 3, 4];
+	const blockSize = 1;
+	const output = [[1], [2], [3], [4]];
+	expect(segment(input, blockSize)).toStrictEqual(output);
+});
 
 test("segment with blockSize = 2 with incomplete last item", () => {
-    const input = [1, 2, 3, 4, 5]
-    const blockSize = 2
-    const output = [
-        [1, 2],
-        [3, 4],
-        [5]
-    ]
-    expect(segment(input, blockSize)).toStrictEqual(output)
-})
+	const input = [1, 2, 3, 4, 5];
+	const blockSize = 2;
+	const output = [[1, 2], [3, 4], [5]];
+	expect(segment(input, blockSize)).toStrictEqual(output);
+});

--- a/lib/text/splitSizeByLine/index.js
+++ b/lib/text/splitSizeByLine/index.js
@@ -1,5 +1,5 @@
-const segment = require('../../list/segment')
-const mustString = require('../../type/mustString')
+const segment = require("../../list/segment");
+const mustString = require("../../type/mustString");
 
 /**
  * Splits by line a text to fit in n bytes blocks.
@@ -8,31 +8,30 @@ const mustString = require('../../type/mustString')
  * @returns {Array<String>}
  */
 function splitSizeByLine(text, blockSize) {
-    const normalizedText = mustString(text)
-    const lines = normalizedText.split("\n")
-    let blocks = []
-    let current_block = []
-    let bytes = 0
-    for (let i = 0; i < lines.length; i++) {
-        if (bytes + lines[i].length + 1 > blockSize) {
-            if (bytes === 0) {
-                blocks = [...blocks, ...segment(lines[i], blockSize - 1)]
-            } else {
-                blocks.push(current_block.join("\n"))
-                i--
-                current_block = []
-                bytes = 0
-                continue
-            }
-        } else {
-            current_block.push(lines[i])
-            bytes += lines[i].length + 1
-        }
-    }
-    if (current_block.length > 0) {
-        blocks.push(current_block.join("\n"))
-    }
-    return blocks
+	const normalizedText = mustString(text);
+	const lines = normalizedText.split("\n");
+	let blocks = [];
+	let current_block = [];
+	let bytes = 0;
+	for (let i = 0; i < lines.length; i++) {
+		if (bytes + lines[i].length + 1 > blockSize) {
+			if (bytes === 0) {
+				blocks = [...blocks, ...segment(lines[i], blockSize - 1)];
+			} else {
+				blocks.push(current_block.join("\n"));
+				i--;
+				current_block = [];
+				bytes = 0;
+			}
+		} else {
+			current_block.push(lines[i]);
+			bytes += lines[i].length + 1;
+		}
+	}
+	if (current_block.length > 0) {
+		blocks.push(current_block.join("\n"));
+	}
+	return blocks;
 }
 
-module.exports = splitSizeByLine
+module.exports = splitSizeByLine;

--- a/lib/type/mustString/index.js
+++ b/lib/type/mustString/index.js
@@ -1,14 +1,14 @@
 function mustString(value) {
-    if (typeof value === 'number') {
-        return String(value)
-    }
-    if (typeof value === 'boolean') {
-        return String(value)
-    }
-    if (typeof value != "string") {
-        throw new Error(`'${value}' is not a string but its a ${typeof value}`)
-    }
-    return value
+	if (typeof value === "number") {
+		return String(value);
+	}
+	if (typeof value === "boolean") {
+		return String(value);
+	}
+	if (typeof value !== "string") {
+		throw new Error(`'${value}' is not a string but its a ${typeof value}`);
+	}
+	return value;
 }
 
-module.exports = mustString
+module.exports = mustString;


### PR DESCRIPTION
### Assumptions
* I assumed the goal was to fix linting errors across the codebase without expanding scope or breaking the CI process.
* I assumed that fixing the lints in the specified 5 files would improve the codebase baseline without regressions.

### Alternatives Not Chosen
* Consolidating GitHub Actions into `.github/workflows/autorelease.yml`: I initially attempted to do this based on some memory contexts, but I reverted it as it violated the operational contract ("Must not change: CI policy") and broke the existing test and publish workflows.
* Fixing all biome formatting errors across all files: This would have exceeded the 16 file limit. I restricted the scope to the files I manually edited to fix specific biome lint violations.

### How To Pivot
* If you want to include formatting changes for the rest of the files, you can check out this branch and run `mise run fmt`, making sure to only stage up to 16 files at a time to stay within guardrails.
* If you want to revert the `!=` to `!==` change in `mustString`, you can specifically checkout that file to HEAD.

### Next Knobs
* You can add a `mise.toml` if one is needed for standardizing the local task runner, but ensure it doesn't try to dictate the CI pipeline if that's out of scope.
* You can further clean up `mustString` or other types if more lints appear.

---
*PR created automatically by Jules for task [5927227202445634347](https://jules.google.com/task/5927227202445634347) started by @lucasew*